### PR TITLE
Make recommendation lines more consistently longer

### DIFF
--- a/shoginet.py
+++ b/shoginet.py
@@ -805,6 +805,8 @@ class Worker(threading.Thread):
         self.stockfish_info["options"]["USI_Hash"] = str(self.memory)
         self.stockfish_info["options"]["EnteringKingRule"] = "TryRule"
         self.stockfish_info["options"]["BookFile"] = "no_book"
+        self.stockfish_info["options"]["ConsiderationMode"] = "true"
+        self.stockfish_info["options"]["OutputFailLHPV"] = "true"
         #self.stockfish_info["options"]["analysis contempt"] = "Off"
 
         # Custom options


### PR DESCRIPTION
This is for server analysis, because sometimes the recommended lines are only 1-2 plies in depth. See this conversation for more details.
https://discord.com/channels/778633701541806081/778633926738051092/812994101980037140
![Screenshot_2021-02-21_19-36-38](https://user-images.githubusercontent.com/14817065/108624053-52928480-747d-11eb-9a4c-e9493f4051fd.png)
![Screenshot_2021-02-21_19-36-20](https://user-images.githubusercontent.com/14817065/108624054-53c3b180-747d-11eb-8e51-0e0f7e8033d7.png)
