### PR TITLE
Add Fairy-Stockfish checkshogi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .vscode/
-*.ini
+shoginet.ini
 YaneuraOu/
 Fairy-Stockfish/
 __pycache__/

--- a/variants.ini
+++ b/variants.ini
@@ -1,0 +1,2 @@
+[checkshogi:shogi]
+checkCounting = true


### PR DESCRIPTION
At the moment I don't have a running lishogi server, however `setoption name VariantPath value variants.ini` seems to work with the latest Fairy-Stockfish as demonstrated by https://lishogi.org/@/FrogfuciusBot .