### PR TITLE
Parallelize building shogi engines to save patience

### DIFF
--- a/build-fairy.sh
+++ b/build-fairy.sh
@@ -31,7 +31,7 @@ if [ -f /proc/cpuinfo ]; then
 fi
 
 echo "- Building $EXE ... (patience advised)"
-make build ARCH=$ARCH EXE=../../$EXE largeboards=yes > /dev/null
+make -j$(nproc || echo 4) build ARCH=$ARCH EXE=../../$EXE largeboards=yes > /dev/null
 
 cd ../..
 echo "- Done!"

--- a/build-yaneuraou.sh
+++ b/build-yaneuraou.sh
@@ -35,7 +35,7 @@ distFile="YaneuraOu-by-gcc-$ARCH"
 
 echo "- Building YANEURAOU $ARCH ... (patience advised)"
 
-make TARGET_CPU=$ARCH YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE COMPILER=$COMP > /dev/null
+make -j$(nproc || echo 4) TARGET_CPU=$ARCH YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE COMPILER=$COMP > /dev/null
 
 cd ../..
 mv ./YaneuraOu/source/YaneuraOu-by-gcc $distFile


### PR DESCRIPTION
`nproc` does not exist on macOS.  I let it fall back to 4.